### PR TITLE
Assets not restricted to staging and prod only

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ This config file requires two environment variables:
 
 To use this config, copy the file `config_with_per_env_credentials.yml.example` to your project's `.circleci/config.yml`.
 
+## Compile assets on other branches than staging and master
+
+If you use more than regular staging and production environment or you want to tell CircleCI to use other branches as base,
+it is possible to pass parameters like so in your `config.yml` file like so:
+
+```yaml
+\"branches-for-assets\":\"('staging' 'master:production' 'other-branch')\",\
+\"assets-buckets\":\"('myapp-staging-assets' 'myapp-production-assets' 'other-asset-bucket')\"
+```
+
+Be aware that `branches-for-assets` param takes a list of branches that you want the CI to compile on.
+Passing a branch name means that environment has the same name (example: `staging`)
+Passing two names separated by `:` means `BRANCH_NAME` `:` `ENVIRONMENT`
+Default value for `branches-for-assets` is `"('master:production' 'staging')"` so you don't have to send this param if
+you don't need more.
+
 ## Tests parallelism
 
 You can enable the tests parallelism by providing the `tests-parallelism` variable with a value greater than 1.

--- a/config.yml.example
+++ b/config.yml.example
@@ -18,6 +18,8 @@ jobs:
             \"project-name\":\"myapp\",\
             \"ruby-version\":\"2.6.6\",\
             \"bundler-version\":\"2.2.2\",\
+            \"branches-for-assets\":\"('staging' 'master:production' 'other-branch')\",\
+            \"assets-buckets\":\"('myapp-staging-assets' 'myapp-production-assets' 'other-asset-bucket')\",\
             \"assets-bucket-staging\":\"myapp-staging-assets\",\
             \"assets-bucket-production\":\"myapp-production-assets\",\
             \"install-redis\":false,\

--- a/configs/rails_config.yml
+++ b/configs/rails_config.yml
@@ -10,6 +10,12 @@ parameters:
   bundler-version:
     type: string
     default: "2.2.16"
+  branches-for-assets:
+    type: string
+    default: "('master:production' 'staging')" # add any branch you want assets to be compiled on
+  assets-buckets:
+    type: string
+    default: "()" # must match branches-for-assets size and order, if not filled, it will be (assets-bucket-production assets-bucket-staging)
   assets-bucket-staging:
     type: string
     default: ""
@@ -110,27 +116,34 @@ jobs:
       - run:
           name: "Compile and serve assets"
           command: |
-            if [ $CIRCLE_BRANCH == staging ]
-            then
-              export ASSETS_ENV=staging
-              export S3_ASSETS_BUCKET=<< pipeline.parameters.assets-bucket-staging >>
-            elif [ $CIRCLE_BRANCH == master ]
-            then
-              export ASSETS_ENV=production
-              export S3_ASSETS_BUCKET=<< pipeline.parameters.assets-bucket-production >>
-            else
-              exit 0
+            branches=<< pipeline.parameters.branches-for-assets >>
+            echo ${branches[@]}
+            assetsBuckets=<< pipeline.parameters.assets-buckets >>
+            if [ ${#assetsBuckets[@]} -eq 0 ]; then
+              assetsBuckets=('<< pipeline.parameters.assets-bucket-production >>' '<< pipeline.parameters.assets-bucket-staging >>')
             fi
 
-            yarn
-            RAILS_ENV=${ASSETS_ENV} bundle exec rake db:create db:migrate
-            RAILS_ENV=${ASSETS_ENV} bundle exec rake assets:clobber assets:precompile
-            aws s3 cp public/assets/ s3://${S3_ASSETS_BUCKET}/assets/ --recursive --acl public-read
+            for i in "${!branches[@]}"; do
+              if [ $CIRCLE_BRANCH == ${branches[$i]%%:*} ]; then
+                export ASSETS_ENV=${branches[$i]##*:}
+                export S3_ASSETS_BUCKET=${assetsBuckets[$i]}
+              fi
+            done
 
-            if [ -d "public/packs" ]; then
-              aws s3 cp public/packs/ s3://${S3_ASSETS_BUCKET}/packs/ --recursive --acl public-read
-            else
-              echo "No public/packs directory, skipping packs upload."
+            if [ -z $ASSETS_ENV ]; then
+              echo "ready to compile assets for env $ASSETS_ENV on assets bucket $S3_ASSETS_BUCKET"
+
+              exit 0
+              yarn
+              RAILS_ENV=${ASSETS_ENV} bundle exec rake db:create db:migrate
+              RAILS_ENV=${ASSETS_ENV} bundle exec rake assets:clobber assets:precompile
+              aws s3 cp public/assets/ s3://${S3_ASSETS_BUCKET}/assets/ --recursive --acl public-read
+
+              if [ -d "public/packs" ]; then
+                aws s3 cp public/packs/ s3://${S3_ASSETS_BUCKET}/packs/ --recursive --acl public-read
+              else
+                echo "No public/packs directory, skipping packs upload."
+              fi
             fi
   security_check:
     working_directory: ~/<< pipeline.parameters.project-name >>
@@ -221,9 +234,6 @@ workflows:
             - assets:
                 context:
                   - ASSETS
-                filters:
-                  branches:
-                    only: ['master', 'staging']
                 requires: ['spec', 'security_check']
             - code_review:
                 filters:

--- a/configs/rails_config.yml
+++ b/configs/rails_config.yml
@@ -117,7 +117,6 @@ jobs:
           name: "Compile and serve assets"
           command: |
             branches=<< pipeline.parameters.branches-for-assets >>
-            echo ${branches[@]}
             assetsBuckets=<< pipeline.parameters.assets-buckets >>
             if [ ${#assetsBuckets[@]} -eq 0 ]; then
               assetsBuckets=('<< pipeline.parameters.assets-bucket-production >>' '<< pipeline.parameters.assets-bucket-staging >>')
@@ -130,10 +129,12 @@ jobs:
               fi
             done
 
-            if [ -z $ASSETS_ENV ]; then
+            if [[ -z "${ASSETS_ENV}" ]]; then
+              echo "ASSETS_ENV var has not been set. Skipping assets compilation."
+              exit 0
+            else
               echo "ready to compile assets for env $ASSETS_ENV on assets bucket $S3_ASSETS_BUCKET"
 
-              exit 0
               yarn
               RAILS_ENV=${ASSETS_ENV} bundle exec rake db:create db:migrate
               RAILS_ENV=${ASSETS_ENV} bundle exec rake assets:clobber assets:precompile

--- a/configs/rails_config_mysql.yml
+++ b/configs/rails_config_mysql.yml
@@ -10,6 +10,12 @@ parameters:
   bundler-version:
     type: string
     default: "2.2.16"
+  branches-for-assets:
+    type: string
+    default: "('master:production' 'staging')" # add any branch you want assets to be compiled on
+  assets-buckets:
+    type: string
+    default: "()" # must match branches-for-assets size and order, if not filled, it will be (assets-bucket-production assets-bucket-staging)
   assets-bucket-staging:
     type: string
     default: ""
@@ -107,27 +113,35 @@ jobs:
       - run:
           name: "Compile and serve assets"
           command: |
-            if [ $CIRCLE_BRANCH == staging ]
-            then
-              export ASSETS_ENV=staging
-              export S3_ASSETS_BUCKET=<< pipeline.parameters.assets-bucket-staging >>
-            elif [ $CIRCLE_BRANCH == master ]
-            then
-              export ASSETS_ENV=production
-              export S3_ASSETS_BUCKET=<< pipeline.parameters.assets-bucket-production >>
-            else
-              exit 0
+            branches=<< pipeline.parameters.branches-for-assets >>
+            assetsBuckets=<< pipeline.parameters.assets-buckets >>
+            if [ ${#assetsBuckets[@]} -eq 0 ]; then
+              assetsBuckets=('<< pipeline.parameters.assets-bucket-production >>' '<< pipeline.parameters.assets-bucket-staging >>')
             fi
 
-            yarn
-            RAILS_ENV=${ASSETS_ENV} bundle exec rake db:create db:migrate
-            RAILS_ENV=${ASSETS_ENV} bundle exec rake assets:clobber assets:precompile
-            aws s3 cp public/assets/ s3://${S3_ASSETS_BUCKET}/assets/ --recursive --acl public-read
+            for i in "${!branches[@]}"; do
+              if [ $CIRCLE_BRANCH == ${branches[$i]%%:*} ]; then
+                export ASSETS_ENV=${branches[$i]##*:}
+                export S3_ASSETS_BUCKET=${assetsBuckets[$i]}
+              fi
+            done
 
-            if [ -d "public/packs" ]; then
-              aws s3 cp public/packs/ s3://${S3_ASSETS_BUCKET}/packs/ --recursive --acl public-read
+            if [[ -z "${ASSETS_ENV}" ]]; then
+              echo "ASSETS_ENV var has not been set. Skipping assets compilation."
+              exit 0
             else
-              echo "No public/packs directory, skipping packs upload."
+              echo "ready to compile assets for env $ASSETS_ENV on assets bucket $S3_ASSETS_BUCKET"
+
+              yarn
+              RAILS_ENV=${ASSETS_ENV} bundle exec rake db:create db:migrate
+              RAILS_ENV=${ASSETS_ENV} bundle exec rake assets:clobber assets:precompile
+              aws s3 cp public/assets/ s3://${S3_ASSETS_BUCKET}/assets/ --recursive --acl public-read
+
+              if [ -d "public/packs" ]; then
+                aws s3 cp public/packs/ s3://${S3_ASSETS_BUCKET}/packs/ --recursive --acl public-read
+              else
+                echo "No public/packs directory, skipping packs upload."
+              fi
             fi
   security_check:
     working_directory: ~/<< pipeline.parameters.project-name >>

--- a/configs/rails_config_with_per_env_credentials.yml
+++ b/configs/rails_config_with_per_env_credentials.yml
@@ -10,6 +10,12 @@ parameters:
   bundler-version:
     type: string
     default: "2.2.16"
+  branches-for-assets:
+    type: string
+    default: "('master:production' 'staging')" # add any branch you want assets to be compiled on
+  assets-buckets:
+    type: string
+    default: "()" # must match branches-for-assets size and order, if not filled, it will be (assets-bucket-production assets-bucket-staging)
   assets-bucket-staging:
     type: string
     default: ""
@@ -108,29 +114,35 @@ jobs:
       - run:
           name: "Compile and serve assets"
           command: |
-            if [ $CIRCLE_BRANCH == staging ]
-            then
-              export ASSETS_KEY=<< pipeline.parameters.rails-master-key-staging >>
-              export ASSETS_ENV=staging
-              export S3_ASSETS_BUCKET=<< pipeline.parameters.assets-bucket-staging >>
-            elif [ $CIRCLE_BRANCH == master ]
-            then
-              export ASSETS_KEY=<< pipeline.parameters.rails-master-key-production >>
-              export ASSETS_ENV=production
-              export S3_ASSETS_BUCKET=<< pipeline.parameters.assets-bucket-production >>
-            else
-              exit 0
+            branches=<< pipeline.parameters.branches-for-assets >>
+            assetsBuckets=<< pipeline.parameters.assets-buckets >>
+            if [ ${#assetsBuckets[@]} -eq 0 ]; then
+              assetsBuckets=('<< pipeline.parameters.assets-bucket-production >>' '<< pipeline.parameters.assets-bucket-staging >>')
             fi
 
-            yarn
-            RAILS_ENV=${ASSETS_ENV} RAILS_MASTER_KEY=${ASSETS_KEY} bundle exec rake db:create db:migrate
-            RAILS_ENV=${ASSETS_ENV} RAILS_MASTER_KEY=${ASSETS_KEY} bundle exec rake assets:clobber assets:precompile
-            aws s3 cp public/assets/ s3://${S3_ASSETS_BUCKET}/assets/ --recursive --acl public-read
+            for i in "${!branches[@]}"; do
+              if [ $CIRCLE_BRANCH == ${branches[$i]%%:*} ]; then
+                export ASSETS_ENV=${branches[$i]##*:}
+                export S3_ASSETS_BUCKET=${assetsBuckets[$i]}
+              fi
+            done
 
-            if [ -d "public/packs" ]; then
-              aws s3 cp public/packs/ s3://${S3_ASSETS_BUCKET}/packs/ --recursive --acl public-read
+            if [[ -z "${ASSETS_ENV}" ]]; then
+              echo "ASSETS_ENV var has not been set. Skipping assets compilation."
+              exit 0
             else
-              echo "No public/packs directory, skipping packs upload."
+              echo "ready to compile assets for env $ASSETS_ENV on assets bucket $S3_ASSETS_BUCKET"
+
+              yarn
+              RAILS_ENV=${ASSETS_ENV} bundle exec rake db:create db:migrate
+              RAILS_ENV=${ASSETS_ENV} bundle exec rake assets:clobber assets:precompile
+              aws s3 cp public/assets/ s3://${S3_ASSETS_BUCKET}/assets/ --recursive --acl public-read
+
+              if [ -d "public/packs" ]; then
+                aws s3 cp public/packs/ s3://${S3_ASSETS_BUCKET}/packs/ --recursive --acl public-read
+              else
+                echo "No public/packs directory, skipping packs upload."
+              fi
             fi
 
   security_check:


### PR DESCRIPTION
Voila une solution pour que le CI accepte de compiler les assets sur n'importe quelle branche et avec n'importe quel nom d'environnement, tout en gardant la configuration dynamique.
C'est un peu plus compliqué que ca ne devrait parce que j'ai voulu garder une rétrocompatibilité avec l'ancienne version.
On peut discuter du truc ensemble si tu veux avant de merger ca sur le master (j'ai deja fait un test sur une branche spécifique de LPB => https://app.circleci.com/pipelines/github/CapSens/la-premiere-brique/2033/workflows/f5b2f023-81c6-4bad-86a5-fa8dd6982e7e/jobs/3096 )