### PR TITLE
[feat/remove-unused-steps] remove code review related steps

### DIFF
--- a/configs/rails_config.yml
+++ b/configs/rails_config.yml
@@ -161,41 +161,6 @@ jobs:
             fi
 
             bundle audit --update $IGNORE
-  code_review:
-    working_directory: ~/<< pipeline.parameters.project-name >>
-    docker:
-      - image: capsens/ruby-node-yarn:<< pipeline.parameters.ruby-version >>
-        environment:
-          RAILS_ENV: test
-    steps:
-      - checkout
-      - run:
-          name: Coding style
-          command: |
-            gem install rubocop
-            mkdir -p rubocop
-            rubocop --format html -o rubocop/rubocop.html || true
-      - run:
-          name: Notation
-          command: |
-            gem install simplecov
-            gem install rubycritic
-            rubycritic app --no-browser
-      - run:
-          name: "Complexité cyclomatique"
-          command: |
-            gem install fukuzatsu
-            fuku check app -f html
-      - run:
-          name: "Axe d'optimisation"
-          command: |
-            gem install fasterer
-            cat \<< EOF > .fasterer.yml
-            exclude_paths:
-              - 'vendor/**/*.rb'
-              - 'db/schema.rb'
-            EOF
-            fasterer || true
       - run:
           name: "Audit de securité de l'application"
           command: |
@@ -204,14 +169,6 @@ jobs:
             brakeman -o security/brakeman.html || true
       - store_artifacts:
           path: security/brakeman.html
-      - store_artifacts:
-          path: rubocop/rubocop.html
-      - store_artifacts:
-          path: tmp/rubycritic
-      - store_artifacts:
-          path: doc/fukuzatsu/htm
-      - store_artifacts:
-          path: coverage
 workflows:
     version: 2
     'workflow':
@@ -225,7 +182,3 @@ workflows:
                   branches:
                     only: ['master', 'staging']
                 requires: ['spec', 'security_check']
-            - code_review:
-                filters:
-                  branches:
-                    only: ['master', 'staging']

--- a/configs/rails_config_mysql.yml
+++ b/configs/rails_config_mysql.yml
@@ -158,41 +158,6 @@ jobs:
             fi
 
             bundle audit --update $IGNORE
-  code_review:
-    working_directory: ~/<< pipeline.parameters.project-name >>
-    docker:
-      - image: capsens/ruby-node-yarn:<< pipeline.parameters.ruby-version >>
-        environment:
-          RAILS_ENV: test
-    steps:
-      - checkout
-      - run:
-          name: Coding style
-          command: |
-            gem install rubocop
-            mkdir -p rubocop
-            rubocop --format html -o rubocop/rubocop.html || true
-      - run:
-          name: Notation
-          command: |
-            gem install simplecov
-            gem install rubycritic
-            rubycritic app --no-browser
-      - run:
-          name: "Complexité cyclomatique"
-          command: |
-            gem install fukuzatsu
-            fuku check app -f html
-      - run:
-          name: "Axe d'optimisation"
-          command: |
-            gem install fasterer
-            cat \<< EOF > .fasterer.yml
-            exclude_paths:
-              - 'vendor/**/*.rb'
-              - 'db/schema.rb'
-            EOF
-            fasterer || true
       - run:
           name: "Audit de securité de l'application"
           command: |
@@ -201,14 +166,6 @@ jobs:
             brakeman -o security/brakeman.html || true
       - store_artifacts:
           path: security/brakeman.html
-      - store_artifacts:
-          path: rubocop/rubocop.html
-      - store_artifacts:
-          path: tmp/rubycritic
-      - store_artifacts:
-          path: doc/fukuzatsu/htm
-      - store_artifacts:
-          path: coverage
 workflows:
     version: 2
     'workflow':
@@ -222,7 +179,3 @@ workflows:
                   branches:
                     only: ['master', 'staging']
                 requires: ['spec', 'security_check']
-            - code_review:
-                filters:
-                  branches:
-                    only: ['master', 'staging']

--- a/configs/rails_config_with_per_env_credentials.yml
+++ b/configs/rails_config_with_per_env_credentials.yml
@@ -162,58 +162,14 @@ jobs:
             fi
 
             bundle audit --update $IGNORE
-
-  code_review:
-    working_directory: ~/<< pipeline.parameters.project-name >>
-    docker:
-      - image: capsens/ruby-node-yarn:<< pipeline.parameters.ruby-version >>
-        environment:
-          RAILS_ENV: test
-    steps:
-      - checkout
-      - run:
-          name: Coding style
-          command: |
-            gem install rubocop
-            mkdir rubocop
-            rubocop --format html -o rubocop/rubocop.html || true
-      - run:
-          name: Notation
-          command: |
-            gem install simplecov
-            gem install rubycritic
-            rubycritic app --no-browser
-      - run:
-          name: "Complexité cyclomatique"
-          command: |
-            gem install fukuzatsu
-            fuku check app -f html
-      - run:
-          name: "Axe d'optimisation"
-          command: |
-            gem install fasterer
-            cat \<< EOF > .fasterer.yml
-            exclude_paths:
-              - 'vendor/**/*.rb'
-              - 'db/schema.rb'
-            EOF
-            fasterer || true
       - run:
           name: "Audit de securité de l'application"
           command: |
             gem install brakeman
-            mkdir security
+            mkdir -p security
             brakeman -o security/brakeman.html || true
       - store_artifacts:
           path: security/brakeman.html
-      - store_artifacts:
-          path: rubocop/rubocop.html
-      - store_artifacts:
-          path: tmp/rubycritic
-      - store_artifacts:
-          path: doc/fukuzatsu/htm
-      - store_artifacts:
-          path: coverage
 
 workflows:
   version: 2
@@ -228,7 +184,3 @@ workflows:
             branches:
               only: ['master', 'staging']
           requires: ['spec', 'security_check']
-      - code_review:
-          filters:
-            branches:
-              only: ['master', 'staging']


### PR DESCRIPTION
- Supprimer les steps related au code review parce-que personne ne s'en sert, ça ralenti les pipelines et si on veut s'en servir, on peut le faire en local. Et ça complexifie le fichier de config.

- Ajouter brakeman dans les security checks, parce-que c'en est un ? Je crois ? 🤔 

Tu en penses quoi ?

Peut-être faire un petit tour de table, savoir si y'a des gens qui se servent des artifacts, mais ça m'étonnerait...