### PR TITLE
Store test results and optimize CircleCI test splitting by timings.

### DIFF
--- a/configs/rails_config_clever_cloud.yml
+++ b/configs/rails_config_clever_cloud.yml
@@ -191,10 +191,19 @@ jobs:
           command: bundle exec rake db:create db:migrate
       - run:
           name: Test
+          no_output_timeout: 15m
           command: |
             yarn
-            circleci tests glob "spec/**/*_spec.rb" | circleci tests split > /tmp/tests-to-run
-            bundle exec rspec $(cat /tmp/tests-to-run)
+            mkdir /tmp/test-results
+            if ! bundle info rspec_junit_formatter > /dev/null 2>&1; then
+              bundle add rspec_junit_formatter
+              bundle install
+            fi
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings > /tmp/tests-to-run
+            bundle exec rspec $(cat /tmp/tests-to-run) --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
+
+      - store_test_results:
+          path: /tmp/test-results
 
   assets:
     working_directory: ~/<< pipeline.parameters.project-name >>

--- a/configs/rails_terraform.yml
+++ b/configs/rails_terraform.yml
@@ -288,10 +288,19 @@ jobs:
           command: bundle exec rake db:create db:migrate
       - run:
           name: Test
+          no_output_timeout: 15m
           command: |
             yarn
-            circleci tests glob "spec/**/*_spec.rb" | circleci tests split > /tmp/tests-to-run
-            bundle exec rspec $(cat /tmp/tests-to-run)
+            mkdir /tmp/test-results
+            if ! bundle info rspec_junit_formatter > /dev/null 2>&1; then
+              bundle add rspec_junit_formatter
+              bundle install
+            fi
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings > /tmp/tests-to-run
+            bundle exec rspec $(cat /tmp/tests-to-run) --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
+
+      - store_test_results:
+          path: /tmp/test-results
 
   security_check:
     working_directory: ~/<< pipeline.parameters.project-name >>

--- a/configs/rails_terraform_mysql.yml
+++ b/configs/rails_terraform_mysql.yml
@@ -288,10 +288,19 @@ jobs:
           command: bundle exec rake db:create db:migrate
       - run:
           name: Test
+          no_output_timeout: 15m
           command: |
             yarn
-            circleci tests glob "spec/**/*_spec.rb" | circleci tests split > /tmp/tests-to-run
-            bundle exec rspec $(cat /tmp/tests-to-run)
+            mkdir /tmp/test-results
+            if ! bundle info rspec_junit_formatter > /dev/null 2>&1; then
+              bundle add rspec_junit_formatter
+              bundle install
+            fi
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings > /tmp/tests-to-run
+            bundle exec rspec $(cat /tmp/tests-to-run) --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
+
+      - store_test_results:
+          path: /tmp/test-results
 
   security_check:
     working_directory: ~/<< pipeline.parameters.project-name >>


### PR DESCRIPTION
- Create `test-results` directory to save RSpec output.
- Conditional installation of rspec_junit_formatter if not already present.
- Execute tests with RspecJunitFormatter to generate JUnit XML results.
- Configure CircleCI to store test results from the test-results directory.
- Update test splitting command to use --split-by=timings for optimized distribution.
- Increase default context timeout from 10 to 15 minutes.

---

ex :

- https://app.circleci.com/pipelines/github/CapSens/Blast/38462/workflows/775a84dd-2491-47d0-8279-a7b752f31daf/jobs/121441
- https://app.circleci.com/pipelines/github/CapSens/Blast/38462/workflows/f562b8e6-15ec-4032-a0bc-22e1d862a144/jobs/121433