### PR TITLE
Display the test split before running them

### DIFF
--- a/configs/rails_config_clever_cloud.yml
+++ b/configs/rails_config_clever_cloud.yml
@@ -194,6 +194,7 @@ jobs:
           command: |
             yarn
             circleci tests glob "spec/**/*_spec.rb" | circleci tests split > /tmp/tests-to-run
+            cat /tmp/tests-to-run
             bundle exec rspec $(cat /tmp/tests-to-run)
 
   assets:

--- a/configs/rails_terraform.yml
+++ b/configs/rails_terraform.yml
@@ -291,6 +291,7 @@ jobs:
           command: |
             yarn
             circleci tests glob "spec/**/*_spec.rb" | circleci tests split > /tmp/tests-to-run
+            cat /tmp/tests-to-run
             bundle exec rspec $(cat /tmp/tests-to-run)
 
   security_check:

--- a/configs/rails_terraform_mysql.yml
+++ b/configs/rails_terraform_mysql.yml
@@ -291,6 +291,7 @@ jobs:
           command: |
             yarn
             circleci tests glob "spec/**/*_spec.rb" | circleci tests split > /tmp/tests-to-run
+            cat /tmp/tests-to-run
             bundle exec rspec $(cat /tmp/tests-to-run)
 
   security_check:


### PR DESCRIPTION
Afficher l'ordre des spec pour éviter de relancer en ssh (le split ne sera pas le meme dans le prochain run)

ex: https://app.circleci.com/pipelines/github/CapSens/Blast/38276/workflows/d6cd0cbf-113c-4162-92cd-6b686eeff19e/jobs/121036/parallel-runs/0/steps/0-108?invite=true#step-108-0_21